### PR TITLE
[feat] Clear all the done wishes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,7 +12,7 @@ function App() {
     <div class="container flex flex-col justify-center items-center gap-4">
       <h1 class="text-4xl font-bold">Solid Bucket List</h1>
       <AddToBucket setItems={setItems} />
-      <ClearDoneWishes />
+      <ClearDoneWishes setItems={setItems} />
       <ul class="text-2xl">
         <For each={items()}>
           {(item) => <BucketListItem item={item} setItems={setItems} />}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,17 +1,18 @@
 import { createSignal } from "solid-js";
 import { BucketListItem } from "./BucketListItem";
 import { AddToBucket } from "./AddToBucket";
+import { ClearDoneWishes } from "./ClearDoneWishes";
 
 import { getWishes } from "./util/localStorageUtil";
 
 function App() {
   const [items, setItems] = createSignal(getWishes());
 
-
   return (
     <div class="container flex flex-col justify-center items-center gap-4">
       <h1 class="text-4xl font-bold">Solid Bucket List</h1>
       <AddToBucket setItems={setItems} />
+      <ClearDoneWishes />
       <ul class="text-2xl">
         <For each={items()}>
           {(item) => <BucketListItem item={item} setItems={setItems} />}

--- a/src/ClearDoneWishes.jsx
+++ b/src/ClearDoneWishes.jsx
@@ -1,0 +1,7 @@
+export function ClearDoneWishes() {
+  return (
+    <button class="px-3 py-1.5 text-xl rounded-md bg-blue-600 text-white capitalize">
+      clear done wishes
+    </button>
+  );
+}

--- a/src/ClearDoneWishes.jsx
+++ b/src/ClearDoneWishes.jsx
@@ -1,6 +1,18 @@
-export function ClearDoneWishes() {
+import { saveWish } from "./util/localStorageUtil";
+
+export function ClearDoneWishes(props) {
   return (
-    <button class="px-3 py-1.5 text-xl rounded-md bg-blue-600 text-white capitalize">
+    <button
+      class="px-3 py-1.5 text-xl rounded-md bg-blue-600 text-white capitalize"
+      onClick={(e) => {
+        e.preventDefault();
+        props.setItems((items) => {
+          const updatedWishes = items.filter((item) => !item.complete);
+          saveWish(updatedWishes);
+          return updatedWishes;
+        });
+      }}
+    >
       clear done wishes
     </button>
   );


### PR DESCRIPTION

![Screenshot from 2023-12-10 12-27-02](https://github.com/tapascript/solid-bucket-list/assets/49482691/36ea05fe-d2f2-4ddf-9206-906464af752b)


This is a proposed feature addition for #9 

## What
- Add a button below the add wish form with the label "Clear Done Wishes".
- Remove the wishes having the `complete` property as `true`

## Why
This is a feature request as the users have no options to remove the completed wishes.